### PR TITLE
src: fix string format mistake for 32 bit node

### DIFF
--- a/src/node_crypto.cc
+++ b/src/node_crypto.cc
@@ -1459,9 +1459,14 @@ static Local<Object> X509ToObject(Environment* env, X509* cert) {
                                     String::kNormalString, mem->length));
       (void) BIO_reset(bio);
 
-      BN_ULONG exponent_word = BN_get_word(rsa->e);
-      BIO_printf(bio, "0x%lx", exponent_word);
-
+      uint64_t exponent_word = static_cast<uint64_t>(BN_get_word(rsa->e));
+      uint32_t lo = static_cast<uint32_t>(exponent_word);
+      uint32_t hi = static_cast<uint32_t>(exponent_word >> 32);
+      if (hi == 0) {
+          BIO_printf(bio, "0x%x", lo);
+      } else {
+          BIO_printf(bio, "0x%x%08x", hi, lo);
+      }
       BIO_get_mem_ptr(bio, &mem);
       info->Set(env->exponent_string(),
                 String::NewFromUtf8(env->isolate(), mem->data,


### PR DESCRIPTION
  warning: format ‘%lx’ expects argument of type ‘long
  unsigned int’, but argument 3 has type ‘unsigned int’ [-Wformat=]
     BIO_printf(bio, "0x%lx", exponent_word);

PR-URL: https://github.com/nodejs/node/pull/10082
Reviewed-By: Anna Henningsen <anna@addaleax.net>
Reviewed-By: Ben Noordhuis <info@bnoordhuis.nl>